### PR TITLE
Drop Terraform experiment, removed in TF 1.3.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,8 +3,7 @@
 ################################################################################
 
 terraform {
-  required_version = ">= 1.0.0"
-  experiments      = [module_variable_optional_attrs]
+  required_version = ">= 1.3.0"
 
   required_providers {
     archive = {


### PR DESCRIPTION
This PR updates the Terraform module to work on TF >= 1.3.0 (current minor release).  The TF experiment `module_variable_optional_attrs` was dropped in v1.3.0, which causes this module to error when used on that version.

See TF 1.3.0 release notes: https://github.com/hashicorp/terraform/releases/tag/v1.3.0